### PR TITLE
Rhmap 9491 fix namespace binding

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-client",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "dependencies": {
     "fh-logger": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib": "lib"
   },
   "engines": {
-    "node": ">=0.8 < 0.11"
+    "node": ">=0.8 <= 4.4"
   },
   "dependencies": {
     "fh-logger": "0.5.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-client
 sonar.projectName=fh-mbaas-client-nightly-master
-sonar.projectVersion=0.15.0
+sonar.projectVersion=0.15.1
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/mbaasRequest/test_mbaasRequest.js
+++ b/test/unit/mbaasRequest/test_mbaasRequest.js
@@ -9,7 +9,7 @@ var log = require('../../../lib/logger/logger').getLogger();
 
 
 module.exports = {
-  before: function(done) {
+  beforeEach: function(done) {
     log.logger.setRequestId('some-request-id', done);
   },
   "It Should Perform App MbaaS Request": function(done) {


### PR DESCRIPTION
# Motivation

There was a failing test because the 'before' function was not binding the downstream functions to the namespace. This was causing expected values not to be set.

# Changes

- Switched to beforeEach to ensure the namespace is bound correctly.