### PR TITLE
RHMAP-9974

### DIFF
--- a/lib/mbaasRequest/mbaasRequest.js
+++ b/lib/mbaasRequest/mbaasRequest.js
@@ -176,22 +176,30 @@ function responseHandler(params, cb) {
       body: body
     });
 
+    // provide defaults
+    if (httpResponse && httpResponse.statusCode >= 400) {
+      err = err || {};
+      err.httpCode = httpResponse.statusCode;
+      err.message = "Unexpected Status Code " + httpResponse.statusCode;
+    }
 
-    if (err || (httpResponse && httpResponse.statusCode >= 400)) {
+    //There is a specific error message if an environment is unreachable
+    if (httpResponse && httpResponse.statusCode === 503) {
+      err = {
+        httpCode: 503,
+        message: CONSTANTS.ERROR_MESSAGES.ENVIRONMENT_UNREACHABLE.replace('{{ENVLABEL}}', params.envLabel || "")
+      };
+    }
 
-      //There is a specific error message if an environment is unreachable
-      if (httpResponse && httpResponse.statusCode) {
-        err = err || {};
-        err.httpCode = httpResponse.statusCode;
-        err.message = "Unexpected Status Code " + httpResponse.statusCode;
-        if (httpResponse.statusCode === 503) {
-          err = {
-            httpCode: 503,
-            message: CONSTANTS.ERROR_MESSAGES.ENVIRONMENT_UNREACHABLE.replace('{{ENVLABEL}}', params.envLabel || "")
-          };
-        }
-      }
+    // MbaaS unavailable
+    if (err && err.code !== undefined && (err.code === "ENOTFOUND" || err.code === "ETIMEDOUT")) {
+      err = {
+        httpCode: httpResponse.statusCode || 500,
+        message: "MBaaS environment is not reachable. Please make the environment available or delete it. Environment Label - " + params.envLabel || ""
+      };
+    }
 
+    if (err) {
       cb(err || body || "Unexpected Status Code " + httpResponse.statusCode);
     } else {
       cb(undefined, body);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-client",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "dependencies": {
     "fh-logger": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-mbaas-client",
   "description": "FeedHenry MBaaS Client",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "author": "FeedHenry",
   "main": "index.js",
   "directories": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-client
 sonar.projectName=fh-mbaas-client-nightly-master
-sonar.projectVersion=0.16.3
+sonar.projectVersion=0.16.4
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/mbaasRequest/test_mbaasRequest.js
+++ b/test/unit/mbaasRequest/test_mbaasRequest.js
@@ -334,7 +334,7 @@ module.exports = {
       done();
     });
   },
-  "It Should respond with a relevant error message when an mbaas is unreachable": function(done){
+  "It Should respond with a relevant error message when an mbaas is unreachable": function(done) {
     var requestStub = sinon.stub().callsArgWith(1, undefined, {
       statusCode: 503
     });
@@ -375,6 +375,100 @@ module.exports = {
 
       sinon.assert.calledOnce(requestStub);
 
+      done();
+    });
+  },
+  "It Should respond with a relevant error message when an mbaas request is timing out": function(done) {
+
+    var mockEnvLabel = "Some Environment Label";
+    var mockErrMessage = "MBaaS environment is not reachable";
+    var statusCode = "501";
+
+    var err = {"code": "ETIMEDOUT"};
+    var mocks = {
+      'request': function(params, cb) {
+        return cb(err, {statusCode: statusCode}, {
+        });
+
+      }
+    };
+
+    var mbaasConf = {
+      username: "someusername",
+      password: "somepassword",
+      url: "https://api.someplace.com",
+      __mbaasUrl: 'https://mbaas.someplace.com',
+      _label: mockEnvLabel
+    };
+
+    var params = {
+      environment: "someenv",
+      domain: "somedomain",
+      resourcePath: "/some/path/to/resource",
+      data: {},
+      method: "GET",
+      paginate: {
+        page: 2,
+        limit: 20
+      }
+    };
+
+    params[constants.MBAAS_CONF_KEY] = mbaasConf;
+
+    var mbaasRequest = proxyquire('../../../lib/mbaasRequest/mbaasRequest.js', mocks);
+
+    mbaasRequest.admin(params, function(err) {
+      assert.ok(err, "Expected an error");
+      assert.ok(err.httpCode.indexOf(statusCode) > -1, "Expected the returned status code to be " + statusCode);
+      assert.ok(err.message.indexOf(mockEnvLabel) > -1, "Expected the enviroment label to be displayed in the error message");
+      assert.ok(err.message.indexOf(mockErrMessage) > -1, "Expected an 'MbaaS unavailable' to be displayed in the error message");
+      done();
+    });
+  },
+  "It Should respond with a relevant error message when an mbaas address is not found": function(done) {
+
+    var mockEnvLabel = "Some Environment Label";
+    var mockErrMessage = "MBaaS environment is not reachable";
+    var statusCode = "502";
+
+    var err = {"code": "ENOTFOUND"};
+    var mocks = {
+      'request': function(params, cb) {
+        return cb(err, {statusCode: statusCode}, {
+        });
+
+      }
+    };
+
+    var mbaasConf = {
+      username: "someusername",
+      password: "somepassword",
+      url: "https://api.someplace.com",
+      __mbaasUrl: 'https://mbaas.someplace.com',
+      _label: mockEnvLabel
+    };
+
+    var params = {
+      environment: "someenv",
+      domain: "somedomain",
+      resourcePath: "/some/path/to/resource",
+      data: {},
+      method: "GET",
+      paginate: {
+        page: 2,
+        limit: 20
+      }
+    };
+
+    params[constants.MBAAS_CONF_KEY] = mbaasConf;
+
+    var mbaasRequest = proxyquire('../../../lib/mbaasRequest/mbaasRequest.js', mocks);
+
+    mbaasRequest.admin(params, function(err) {
+      assert.ok(err, "Expected an error");
+      assert.ok(err.httpCode.indexOf(statusCode) > -1, "Expected the returned status code to be " + statusCode);
+      assert.ok(err.message.indexOf(mockEnvLabel) > -1, "Expected the enviroment label to be displayed in the error message");
+      assert.ok(err.message.indexOf(mockErrMessage) > -1, "Expected an 'MbaaS unavailable' to be displayed in the error message");
       done();
     });
   }


### PR DESCRIPTION
**Motivation**
Users are unable to delete projects if the domain contains an environment that is pointing to an Openshift Enterprise 3 MBaaS target that is no longer reachable (Deleted for example).
The behavior in the studio is that all the contents of the project are deleted (ie apps and cloud apps) but after ~1 minute of waiting the user gets an error saying "Failed to delete project.". The on prem team recommended adding a message for 4.2 to describe why project deletion fails.

**Edit**: Resolved conflicts and fixed bug introduced by a previous PR.