### PR TITLE
RHMAP-10352 - Changed so that auth section is inserted only if credentials are present.

### DIFF
--- a/lib/mbaasRequest/mbaasRequest.js
+++ b/lib/mbaasRequest/mbaasRequest.js
@@ -126,10 +126,6 @@ function _buildAdminMbaasParams(params) {
   var adminRequestParams = {
     url: parsedMbaasUrl.format(),
     method: method,
-    auth: {
-      user: params.username,
-      pass: params.password
-    },
     headers: {
       host: parsedMbaasUrl.host,
       'x-fh-service-key': params.servicekey
@@ -140,6 +136,13 @@ function _buildAdminMbaasParams(params) {
     paginate: params.paginate,
     envLabel: params._label
   };
+
+  if (params.username && params.password) {
+    adminRequestParams.auth = {
+      user: params.username,
+      pass: params.password
+    };
+  }
 
   log.logger.debug({adminRequestParams: adminRequestParams}, "FH-MBAAS-CLIENT: _buildAdminMbaasParams");
   return adminRequestParams;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-client",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "dependencies": {
     "fh-logger": {
       "version": "0.5.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-client",
-  "version": "0.15.1",
+  "version": "0.16.2",
   "dependencies": {
     "fh-logger": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-mbaas-client",
   "description": "FeedHenry MBaaS Client",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "author": "FeedHenry",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-mbaas-client",
   "description": "FeedHenry MBaaS Client",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "author": "FeedHenry",
   "main": "index.js",
   "directories": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-client
 sonar.projectName=fh-mbaas-client-nightly-master
-sonar.projectVersion=0.15.1
+sonar.projectVersion=0.16.2
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-client
 sonar.projectName=fh-mbaas-client-nightly-master
-sonar.projectVersion=0.16.2
+sonar.projectVersion=0.16.3
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
# Motivation
Metric collection did not work on openshift because, when the credentials are not needed, the request produced was similar to:

```
{
     "url": "https://mbaas-core-mbaas.ziccardi-ose3.skunkhenry.com/api/mbaas/metrics",
     "method": "GET",
     "auth": {},
     "headers": {
       "host": "mbaas-core-mbaas.ziccardi-ose3.skunkhenry.com",
       "x-fh-service-key": "BTvumU7yfvg8mCa4CyXlwfWLuyK31bsSJvwRwaNs"
     },
     "data": {
       "from": 1471219200000,
       "to": 1473897599999
     }
   }
```

This created the 'no auth mechanism' issue.